### PR TITLE
 Add root_folder argument to validate_to_array function.

### DIFF
--- a/2 Summarization.ipynb
+++ b/2 Summarization.ipynb
@@ -1204,7 +1204,7 @@
     "    w2_vec = E[w2_index] # Get the embedding vector of the second word\n",
     "    \n",
     "    print(w1,\" vs. \", w2, \"similarity:\",cosine_sim(w1_vec, w2_vec))\n",
-    "validate_to_array(lambda f,i: (f(*i),i), (cosine_sim,tuple(20*np.random.random((2,1000))-1)),'cosine_sim', root_folder) "
+    "validate_to_array(lambda f,i: (f(*i),i), (cosine_sim,tuple(20*np.random.random((2,1000))-1)),'cosine_sim') "
    ]
   },
   {

--- a/2 Summarization.ipynb
+++ b/2 Summarization.ipynb
@@ -1204,7 +1204,7 @@
     "    w2_vec = E[w2_index] # Get the embedding vector of the second word\n",
     "    \n",
     "    print(w1,\" vs. \", w2, \"similarity:\",cosine_sim(w1_vec, w2_vec))\n",
-    "validate_to_array(lambda f,i: (f(*i),i), (cosine_sim,tuple(20*np.random.random((2,1000))-1)),'cosine_sim') "
+    "validate_to_array(lambda f,i: (f(*i),i), (cosine_sim,tuple(20*np.random.random((2,1000))-1)),'cosine_sim', root_folder) "
    ]
   },
   {


### PR DESCRIPTION
`r` argument is missing in the last cell of the Summarization.ipynb notebook (`validate_to_array` function).

``` python
validate_to_array(lambda f,i: (f(*i),i), (cosine_sim,tuple(20*np.random.random((2,1000))-1)),'cosine_sim', root_folder) 
```